### PR TITLE
Preserve non-empty PROJECT_FILES environment variable

### DIFF
--- a/commands/web/symlink-project
+++ b/commands/web/symlink-project
@@ -14,9 +14,12 @@ export _WEB_ROOT=$DDEV_DOCROOT
 cd "$DDEV_COMPOSER_ROOT" || exit
 curl -OL https://git.drupalcode.org/project/gitlab_templates/-/raw/default-ref/scripts/symlink_project.php
 
-# Suppress a warning.
-PROJECT_FILES=$(ls -A --ignore="web" --ignore="vendor" --ignore="symlink_project.php" --ignore=".ddev" --ignore=".idea")
-export PROJECT_FILES
+if [ -z "$PROJECT_FILES" ]; then
+  # Suppress a warning.
+  PROJECT_FILES=$(ls -A --ignore="web" --ignore="vendor" --ignore="symlink_project.php" --ignore=".ddev" --ignore=".idea")
+  export PROJECT_FILES
+fi
+
 # Symlink name using underscores.
 # @see https://www.drupal.org/docs/develop/creating-modules/naming-and-placing-your-drupal-module
 php symlink_project.php "${DDEV_SITENAME//-/_}"


### PR DESCRIPTION
## The Issue

- The PR contains the issue scope

In some projects developers might want to control themselves the list of root files and directories that are symlinked. Right now, the `symlink-project` command overrides any pre-existing environment variable.

## How This PR Solves The Issue

Only compute and export `PROJECT_FILES` it a non-empty value doesn't exist already.

## Manual Testing Instructions

1. Create a file `.ddev/.env` wit the following content:
   ```
   PROJECT_FILES="
   my_module.info.yml
   my_module.install
   my_module.module
   src
   "
1. Restart DDEV: `ddev restart`
1. Run `ddev symlink-project`
1. Check the directory `web/modules/custom/my_module` for the created symlinks 

## Automated Testing Overview

N/A

## Release/Deployment Notes

N/A
